### PR TITLE
fix: Add render errors to compilation

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -264,7 +264,11 @@ export = class HtmlRenderPlugin<Route extends BaseRoute = BaseRoute> {
         compilationStatus.compilation = compilation;
         lastClientStats = null;
         compilationStatus.isReady = true;
-        await createRendererIfReady(compilation);
+        try {
+          await createRendererIfReady(compilation);
+        } catch (error) {
+          compilation.errors.push(error);
+        }
       });
     };
     this.statsCollectorPlugin = (compiler: Compiler) => apply(compiler, false);


### PR DESCRIPTION
Errors occured during rendering or the creation of the renderer should be added to the compilation rather than thrown. This allows webpack to re-run failed builds when source code changes.