### PR TITLE
fix: Ensure TypeScript types can be used from node_modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # html-render-webpack-plugin
 
+[![npm](https://img.shields.io/npm/v/html-render-webpack-plugin.svg)](https://www.npmjs.com/package/html-render-webpack-plugin)
+
 Plugin to create HTML files with JavaScript.
 
 - Supports [multiple configurations](https://webpack.js.org/configuration/configuration-types/#exporting-multiple-configurations)

--- a/src/createDevRouter.ts
+++ b/src/createDevRouter.ts
@@ -7,7 +7,7 @@ import {
   WebpackStats,
   TransformExpressPath,
   GetRouteFromRequest,
-} from "common-types";
+} from "./common-types";
 import { Stats } from "webpack";
 
 interface Params<Route> {

--- a/src/createRenderer.ts
+++ b/src/createRenderer.ts
@@ -1,5 +1,5 @@
 import evalutateFromSource from "./evalutateFromSource";
-import { SourceModules, ExtraGlobals } from "common-types";
+import { SourceModules, ExtraGlobals } from "./common-types";
 
 export = function createRenderer({
   fileName,

--- a/src/evalutateFromSource.ts
+++ b/src/evalutateFromSource.ts
@@ -1,6 +1,6 @@
 import path from "path";
 import evaluate from "eval";
-import { SourceModules, ExtraGlobals } from "common-types";
+import { SourceModules, ExtraGlobals } from "./common-types";
 
 import { log } from "./logging";
 

--- a/src/getSourceFromCompilation.ts
+++ b/src/getSourceFromCompilation.ts
@@ -1,5 +1,5 @@
 import { compilation } from "webpack";
-import { SourceModules } from "common-types";
+import { SourceModules } from "./common-types";
 
 export = function getSourceFromCompilation(comp: compilation.Compilation) {
   const files: SourceModules = {};

--- a/src/renderRoutes.ts
+++ b/src/renderRoutes.ts
@@ -1,6 +1,6 @@
 import path from "path";
 import chalk from "chalk";
-import { RenderConcurrency, TransformPath, Render } from "common-types";
+import { RenderConcurrency, TransformPath, Render } from "./common-types";
 import { compilation } from "webpack";
 import { log } from "./logging";
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,7 @@
     "noImplicitReturns": true /* Report error when not all code paths in function return a value. */,
     "noFallthroughCasesInSwitch": true /* Report errors for fallthrough cases in switch statement. */,
     "moduleResolution": "node" /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */,
-    "baseUrl": "./src" /* Base directory to resolve non-absolute module names. */,
+    "baseUrl": "./" /* Base directory to resolve non-absolute module names. */,
     // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
     // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
     // "typeRoots": [


### PR DESCRIPTION
Currently the reference from common-types doesn't use the correct path to be accessble in node_modules. This causes errrors for consumers using TypeScript.
New Path:
```ts
/// <reference types="./src/types/types" />
```