### PR TITLE
fix: Resolve external packages from root dir

### DIFF
--- a/src/evaluateFromFileSystem.ts
+++ b/src/evaluateFromFileSystem.ts
@@ -58,7 +58,9 @@ function createLinker(
     const absPath = path.join(path.dirname(parentModulePath), specifier);
     if (!getFromSourceModules(specifier, fsModule, rootDir)) {
       log(`Using external require for ${specifier} from ${parentModulePath}`);
-      return require(specifier);
+      const resolvedPath = require.resolve(specifier, { paths: [rootDir] });
+      log(`Resolved ${specifier} as external package to ${resolvedPath}`);
+      return require(resolvedPath);
     }
     log(`Linking ${parentModulePath} to asset ${specifier}`);
     return evaluateFromFileSystem(absPath, fsModule, rootDir, extraGlobals);


### PR DESCRIPTION
With pnpm's linking behaviour we should no-longer rely on hoisting. Any dependencies used by the user's code should be resolved from the output directory.